### PR TITLE
Fix solc cmd reading stdin bug

### DIFF
--- a/pkg/solc/solc.go
+++ b/pkg/solc/solc.go
@@ -41,7 +41,9 @@ func Execute() {
 
 	name := fmt.Sprintf("solc-%s", currentVersion)
 	filePath := filepath.Join(config.SolcArtifacts, name, name)
-	out, err := exec.Command(filePath, args...).CombinedOutput()
+	cmd := exec.Command(filePath, args...)
+	cmd.Stdin = os.Stdin
+	out, err := cmd.CombinedOutput()
 
 	if err == nil {
 		fmt.Print(string(out))


### PR DESCRIPTION
Now `solc` cmd doesn't read STDIN, this make it can't work normally when using `-` as filename.

Before:
```bash
$ echo "pragma solidity >=0.5.0; contract Foo {}" | go run github.com/fabelx/go-solc-select/cmd/solc --bin -
Warning: SPDX license identifier not provided in source file. Before publishing, consider adding a comment containing "SPDX-License-Identifier: <SPDX-License>" to each source file. Use "SPDX-License-Identifier: UNLICENSED" for non-open-source code. Please see https://spdx.org for more information.
--> <stdin>

Warning: Source file does not specify required compiler version! Consider adding "pragma solidity ^0.8.16;"
--> <stdin>
```
After: 
```bash
$ echo "pragma solidity >=0.5.0; contract Foo {}" | go run github.com/fabelx/go-solc-select/cmd/solc --bin -
Warning: SPDX license identifier not provided in source file. Before publishing, consider adding a comment containing "SPDX-License-Identifier: <SPDX-License>" to each source file. Use "SPDX-License-Identifier: UNLICENSED" for non-open-source code. Please see https://spdx.org for more information.
--> <stdin>


======= <stdin>:Foo =======
Binary:
6080604052348015600f57600080fd5b50603f80601d6000396000f3fe6080604052600080fdfea26469706673582212204ec986342623593675c24dae3b2e8832dc18789b3ca8927cc82a7cc0bb9b76d864736f6c63430008100033
```